### PR TITLE
Revert updating deprecated WriterName/CreatorName refs

### DIFF
--- a/src/Umbraco.Web/PublishedContentExtensions.cs
+++ b/src/Umbraco.Web/PublishedContentExtensions.cs
@@ -1213,8 +1213,8 @@ namespace Umbraco.Web
                                     { "NodeTypeAlias", n.ContentType.Alias },
                                     { "CreateDate", n.CreateDate },
                                     { "UpdateDate", n.UpdateDate },
-                                    { "CreatorName", n.CreatorName(services.UserService) },
-                                    { "WriterName", n.WriterName(services.UserService) },
+                                    { "CreatorName", n.CreatorName },
+                                    { "WriterName", n.WriterName },
                                     { "Url", n.Url() }
                                 };
 


### PR DESCRIPTION
Changing the properties to use the extensions is a good thing (given the props are deprecated), but causes issues deep in tests. I'm reverting that change to fix the tests, and all refs to the deprecated properties should be updated in one sweep, to deal with any other test issues that might crop up.

No changes in behavior, other than tests no longer failing.