### PR TITLE
Exit early in setupViewModel function

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/boolean/boolean.controller.js
@@ -26,12 +26,21 @@ function booleanEditorController($scope) {
         $scope.renderModel = {
             value: false
         };
-
-        if ($scope.model.config && $scope.model.config.default && Object.toBoolean($scope.model.config.default) && $scope.model && !$scope.model.value) {
-            $scope.renderModel.value = true;
+        
+        // if no model, the subsequent conditions will both fail
+        // so instead let's exit early
+        if (!$scope.model) {
+            return;
         }
 
-        if ($scope.model && $scope.model.value && Object.toBoolean($scope.model.value)) {
+        if ($scope.model.config && $scope.model.config.default && Object.toBoolean($scope.model.config.default) && !$scope.model.value) {
+            $scope.renderModel.value = true;
+            // no need to check the final condition as
+            // the value is already set to true
+            return;
+        }
+
+        if ($scope.model.value && Object.toBoolean($scope.model.value)) {
             $scope.renderModel.value = true;
         }
     }


### PR DESCRIPTION
No need to check both value-setting conditions - if the first is true, we can exit as the second will have no effect on the model value. Similarly, exits if $scope.model is null, since both value-setting conditions will fail.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
